### PR TITLE
Refactor the way the 'watch' checkbox works. On the UI side this is i…

### DIFF
--- a/django/econsensus/publicweb/single_action_views.py
+++ b/django/econsensus/publicweb/single_action_views.py
@@ -1,0 +1,68 @@
+from actionitems.models import ActionItem
+from django.views.generic.base import View
+from django.http import HttpResponseRedirect
+from notification import models as notification
+from publicweb.models import Decision
+from signals.management import DECISION_CHANGE
+
+
+class BaseSingleActionView(View):
+    """ SingleActionViews are views used to perform a single, simple
+        action such as marking an item as done. This used with a
+        redirection to provide quick, one-click actions that do
+        not require javascript.
+
+        - Users need to provide a URL route to the single action view;
+        - Descendant classes should implement a single 'do_action'
+        method to perform the action;
+        - Requests are expected to contains a GET parameter 'next' then the
+        user will be redirected to the given URL.
+    """
+    def get(self, request, *args, **kwargs):
+        self.do_action()
+        return HttpResponseRedirect(request.GET['next'])
+
+
+class BaseWatcherView(BaseSingleActionView):
+    """ Base single action view for add/remove watcher views """
+    def get_object(self):
+        object_id = self.kwargs['decision_id']
+        decision = Decision.objects.get(pk=object_id)
+        return decision
+
+    def get_user(self):
+        return self.request.user
+
+
+class AddWatcher(BaseWatcherView):
+    """ Single action view used to add a new watcher to a decision """
+    def do_action(self):
+        decision = self.get_object()
+        user = self.get_user()
+        notification.observe(decision, user, DECISION_CHANGE)
+
+
+class RemoveWatcher(BaseWatcherView):
+    """ Single action view used to remove a watcher from a decision """
+    def do_action(self):
+        decision = self.get_object()
+        user = self.get_user()
+        notification.stop_observing(decision, user)
+
+
+class SetActionItemDone(View):
+    """ Single action view used to set an action item as done """
+    def do_action(self):
+        actionitem = ActionItem.objects.get(pk=self.kwargs['actionitem_id'])
+        if actionitem:
+            actionitem.done = True
+            actionitem.save()
+
+
+class UnsetActionItemDone(View):
+    """ Single action view used to unset an action item's done status """
+    def do_action(self):
+        actionitem = ActionItem.objects.get(pk=self.kwargs['actionitem_id'])
+        if actionitem:
+            actionitem.done = False
+            actionitem.save()

--- a/django/econsensus/publicweb/tests/set_action_item_done_view_test.py
+++ b/django/econsensus/publicweb/tests/set_action_item_done_view_test.py
@@ -1,0 +1,8 @@
+from actionitems.models import ActionItem
+from django.core.urlresolvers import reverse
+from publicweb.tests.decision_test_case import DecisionTestCase
+
+class SetActionItemDoneViewTest(DecisionTestCase):
+    def test_invoking_view_marks_action_as_done(self):
+        action = ActionItem(description='some action')
+        

--- a/django/econsensus/publicweb/urls.py
+++ b/django/econsensus/publicweb/urls.py
@@ -11,7 +11,9 @@ from views import (DecisionCreate, DecisionUpdate, DecisionDetail, DecisionList,
                     EconsensusActionitemDetailView, DecisionSearchView)
 
 from models import Feedback
-from publicweb.views import AddWatcher, RemoveWatcher
+from publicweb.single_action_views import (AddWatcher, RemoveWatcher,
+                                           SetActionItemDone, 
+                                           UnsetActionItemDone)
 
 
 urlpatterns = patterns('econsensus.publicweb.views',
@@ -20,10 +22,16 @@ urlpatterns = patterns('econsensus.publicweb.views',
         name='your_details'),
     url(r'^user_settings/notification_settings/(?P<org_slug>[-\w]+)/$',
         UserNotificationSettings.as_view(), name='notification_settings'),
+        
+    # Single action urls
     url(r'^add_watcher/(?P<decision_id>\d+)/$', AddWatcher.as_view(),
         name="add_watcher"),
     url(r'^remove_watcher/(?P<decision_id>\d+)/$', RemoveWatcher.as_view(),
-        name="remove_watcher"),
+        name="remove_watcher"),        
+    url(r'^set_actionitem_done/(?P<actionitem_id>\d+)/$', SetActionItemDone.as_view(),
+        name="set_actionitem_done"),
+    url(r'^unset_actionitem_done/(?P<actionitem_id>\d+)/$', UnsetActionItemDone.as_view(),
+        name="unset_actionitem_done"),
 
     url(r'^(?P<org_slug>[-\w]+)/export_csv/$',
         ExportCSV.as_view(),

--- a/django/econsensus/publicweb/views.py
+++ b/django/econsensus/publicweb/views.py
@@ -944,29 +944,3 @@ class DecisionSearchView(SearchView):
         def search_view(request, *args, **kwargs):
             return cls()(request, *args, **kwargs)
         return login_required(search_view)
-
-
-class BaseWatcherView(View):
-    def get_object(self):
-        object_id = self.kwargs['decision_id']
-        decision = Decision.objects.get(pk=object_id)
-        return decision
-
-    def get_user(self):
-        return self.request.user
-
-
-class AddWatcher(BaseWatcherView):
-    def get(self, request, *args, **kwargs):
-        decision = self.get_object()
-        user = self.get_user()
-        notification.observe(decision, user, DECISION_CHANGE)
-        return HttpResponseRedirect(request.GET['next'])
-
-
-class RemoveWatcher(BaseWatcherView):
-    def get(self, request, *args, **kwargs):
-        decision = self.get_object()
-        user = self.get_user()
-        notification.stop_observing(decision, user)
-        return HttpResponseRedirect(request.GET['next'])


### PR DESCRIPTION
…mplemented as a checkbox within a link. Clicking on it calls a view on the server, then reloads the existing page with the change applied. This makes it possible to have such action happen on clicking a tick box (rather than then having to press submit) without relying on javascript. So far this approach was only used for the 'watch' box. As we are introducing the same functionality for the 'done' checkbox, there could be a need for some refactoring. This is an experiment at finding a small refactoring, which formalizes this approach without trying to change the way it's implemented. As such it names such 'checkbox' action Single Action Views, and moves them in a file of their own, with their own base class. It may be that this is not the best approach, and either no refactoring, or rethinking the way this is implemented is a more adequate course of action.
